### PR TITLE
[NOCSL] Update url encode for path

### DIFF
--- a/src/Constructorio_NET.Tests/utils/HelpersTest.cs
+++ b/src/Constructorio_NET.Tests/utils/HelpersTest.cs
@@ -99,6 +99,25 @@ namespace Constructorio_NET.Tests
         }
 
         [Test]
+        public void MakeUrlShouldEncodeSpaceProperly()
+        {
+            List<string> paths = new List<string> { "search space", this.Query };
+            Dictionary<string, List<string>> filters = new Dictionary<string, List<string>>()
+            {
+                { "Color", new List<string>() { "green shirt", "blue" } }
+            };
+            Hashtable queryParams = new Hashtable()
+            {
+                { Constants.FILTERS, filters }
+            };
+
+            string url = MakeUrl(this.Options, paths, queryParams);
+            string expectedUrl = $@"https:\/\/ac.cnstrc.com\/search%20space\/{this.Query}\?key={this.ApiKey}&c={this.Version}&filters%5BColor%5D=green%20shirt&filters%5BColor%5D=blue&_dt=";
+            bool regexMatched = Regex.Match(url, expectedUrl).Success;
+            Assert.That(regexMatched, "url should be properly formed");
+        }
+
+        [Test]
         public void MakeUrlSearchWithTestCells()
         {
             List<string> paths = new List<string> { "search", this.Query };

--- a/src/constructor.io/utils/Helpers.cs
+++ b/src/constructor.io/utils/Helpers.cs
@@ -73,7 +73,7 @@ namespace Constructorio_NET.Utils
 
             foreach (var path in paths)
             {
-                url.Append($"/{HttpUtility.UrlEncode(path)}");
+                url.Append($"/{HttpUtility.UrlPathEncode(path)}");
             }
 
             url.Append($"?{Constants.API_KEY}={options[Constants.API_KEY]}");


### PR DESCRIPTION
Previously we were encoding the path using the UrlEncode function. This changes it to use the UrlPathEncode function to properly encode spaces to %20 instead of +