### PR TITLE
[CSL-2190] allow empty user info

### DIFF
--- a/src/constructor.io/models/common/UserInfo.cs
+++ b/src/constructor.io/models/common/UserInfo.cs
@@ -22,6 +22,10 @@ namespace Constructorio_NET.Models
             this.SetClientId(clientId);
         }
 
+        public UserInfo()
+        {
+        }
+
         public string GetClientId()
         {
             return this.clientId;


### PR DESCRIPTION
Allowing empty UserInfo constructor for when users have no client/sessionId. 