### PR TITLE
[NOCSL] Remove validation for user agent header.

### DIFF
--- a/src/constructor.io/utils/Helpers.cs
+++ b/src/constructor.io/utils/Helpers.cs
@@ -228,7 +228,11 @@ namespace Constructorio_NET.Utils
 
             foreach (var header in requestHeaders)
             {
-                httpRequest.Headers.Add(header.Key, header.Value);
+                if (header.Key == Constants.USER_AGENT) {
+                    httpRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                } else {
+                    httpRequest.Headers.Add(header.Key, header.Value);
+                }
             }
 
             if (options.ContainsKey(Constants.CONSTRUCTOR_TOKEN))


### PR DESCRIPTION
User agent validation was providing issues for customer's headers in facebook browser, certain IOS betas. 