### PR TITLE
Change target framework for tests

### DIFF
--- a/src/Constructorio_NET.Tests/Constructorio_NET.Tests.csproj
+++ b/src/Constructorio_NET.Tests/Constructorio_NET.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <ReleaseVersion>2.9.0</ReleaseVersion>


### PR DESCRIPTION
if tests don't run you need to go to the `Constructorio_NET.Tests` directory and run `dotnet restore`