### PR TITLE
[CSL-2445] Make http client public

### DIFF
--- a/src/constructor.io/client/ConstructorIO.cs
+++ b/src/constructor.io/client/ConstructorIO.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Net.Http;
 using Constructorio_NET.Models;
 using Constructorio_NET.Modules;
 using Constructorio_NET.Utils;
@@ -20,6 +21,7 @@ namespace Constructorio_NET
         public Tasks Tasks { get; }
         public Items Items { get; }
         public Quizzes Quizzes { get; }
+        public static readonly HttpClient HttpClient = new HttpClient();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConstructorIO"/> class.

--- a/src/constructor.io/utils/Helpers.cs
+++ b/src/constructor.io/utils/Helpers.cs
@@ -13,7 +13,7 @@ namespace Constructorio_NET.Utils
 {
     public class Helpers
     {
-        private static readonly HttpClient Client = new HttpClient();
+        private readonly HttpClient Client = ConstructorIO.HttpClient;
 
         protected Helpers()
         {

--- a/src/constructor.io/utils/Helpers.cs
+++ b/src/constructor.io/utils/Helpers.cs
@@ -13,8 +13,6 @@ namespace Constructorio_NET.Utils
 {
     public class Helpers
     {
-        private readonly HttpClient Client = ConstructorIO.HttpClient;
-
         protected Helpers()
         {
         }
@@ -270,7 +268,7 @@ namespace Constructorio_NET.Utils
                 httpRequest.Content = reqContent;
             }
 
-            HttpResponseMessage response = await Client.SendAsync(httpRequest);
+            HttpResponseMessage response = await ConstructorIO.HttpClient.SendAsync(httpRequest);
             HttpContent resContent = response.Content;
             string result = await resContent.ReadAsStringAsync();
 


### PR DESCRIPTION
Moving http client up to ConstructorIO object, making it public so users can configure, change the http client.