### PR TITLE
[CI-2267] Add support for filtering on specific sections in Autocomplete

### DIFF
--- a/src/Constructorio_NET.Tests/client/modules/AutocompleteTests.cs
+++ b/src/Constructorio_NET.Tests/client/modules/AutocompleteTests.cs
@@ -141,6 +141,37 @@ namespace Constructorio_NET.Tests
             Assert.NotNull(res.ResultId, "Result id exists");
             Assert.GreaterOrEqual(res.Sections["Products"].Count, 1, "Results exist");
         }
+
+        [Test]
+        public async Task GetAutocompleteResultsShouldReturnResultWithFiltersPerSection()
+        {
+            Dictionary<string, List<string>> filters = new Dictionary<string, List<string>>();
+
+            AutocompleteRequest req = new AutocompleteRequest("item")
+            {
+                UserInfo = UserInfo,
+                FiltersPerSection = new Dictionary<string, Dictionary<string, List<string>>>()
+            };
+
+            filters.Add("group_id", new List<string> { "All" });
+            req.FiltersPerSection.Add("Products", filters);
+            ConstructorIO constructorio = new ConstructorIO(this.Config);
+            AutocompleteResponse res = await constructorio.Autocomplete.GetAutocompleteResults(req);
+
+            Assert.NotNull(res.ResultId, "Result id exists");
+
+            object responseFilters;
+            res.Request.TryGetValue("filters", out responseFilters);
+
+            JObject parsedResponseFilters = (JObject)responseFilters;
+            Assert.NotNull(parsedResponseFilters, "Filters exist in response");
+
+            JObject productsSection = (JObject)parsedResponseFilters["Products"];
+            Assert.NotNull(productsSection, "Section exist in filters");
+
+            JArray filterValues = (JArray)productsSection["group_id"];
+            Assert.GreaterOrEqual(filterValues.Count, 1, "Results exist");
+            Assert.AreEqual("All", filterValues.First.ToString());
+        }
     }
 }
-

--- a/src/Constructorio_NET.Tests/client/modules/AutocompleteTests.cs
+++ b/src/Constructorio_NET.Tests/client/modules/AutocompleteTests.cs
@@ -49,7 +49,7 @@ namespace Constructorio_NET.Tests
 
             labels.TryGetValue("is_sponsored", out object isSponsored);
 
-            Assert.AreEqual((bool)isSponsored, true);
+            Assert.AreEqual(true, (bool)isSponsored);
             Assert.NotNull(res.ResultId, "Result id exists");
         }
 

--- a/src/Constructorio_NET.Tests/client/modules/BrowseTests.cs
+++ b/src/Constructorio_NET.Tests/client/modules/BrowseTests.cs
@@ -55,7 +55,7 @@ namespace Constructorio_NET.Tests
 
             labels.TryGetValue("is_sponsored", out object isSponsored);
 
-            Assert.AreEqual((bool)isSponsored, true);
+            Assert.AreEqual(true, (bool)isSponsored);
             Assert.Greater(
                 res.Response.TotalNumResults,
                 0,
@@ -901,4 +901,3 @@ namespace Constructorio_NET.Tests
         }
     }
 }
-

--- a/src/Constructorio_NET.Tests/client/modules/SearchTests.cs
+++ b/src/Constructorio_NET.Tests/client/modules/SearchTests.cs
@@ -48,7 +48,7 @@ namespace Constructorio_NET.Tests
 
             labels.TryGetValue("is_sponsored", out object isSponsored);
 
-            Assert.AreEqual((bool)isSponsored, true);
+            Assert.AreEqual(true, (bool)isSponsored);
             Assert.Greater(
                 res.Response.TotalNumResults,
                 0,
@@ -742,4 +742,3 @@ namespace Constructorio_NET.Tests
         }
     }
 }
-

--- a/src/Constructorio_NET.Tests/models/Autocomplete/AutocompleteRequestTest.cs
+++ b/src/Constructorio_NET.Tests/models/Autocomplete/AutocompleteRequestTest.cs
@@ -17,6 +17,10 @@ namespace Constructorio_NET.Tests
         {
             { "Color", new List<string>() { "green", "blue" } }
         };
+        private readonly Dictionary<string, Dictionary<string, List<string>>> FiltersPerSection = new Dictionary<string, Dictionary<string, List<string>>>()
+        {
+            { "Products", new Dictionary<string, List<string>>() { { "Color", new List<string>() { "green", "blue" } } } }
+        };
         private readonly string UserId = "user1";
         private readonly List<string> UserSegments = new List<string>() { "us", "desktop" };
         private readonly Dictionary<string, string> TestCells = new Dictionary<string, string>()
@@ -45,6 +49,7 @@ namespace Constructorio_NET.Tests
                 UserInfo = this.UserInfo,
                 Filters = this.Filters,
                 TestCells = this.TestCells,
+                FiltersPerSection = this.FiltersPerSection,
             };
 
             Hashtable requestParameters = req.GetRequestParameters();
@@ -54,6 +59,7 @@ namespace Constructorio_NET.Tests
             Assert.AreEqual(this.UserSegments, requestParameters[Constants.USER_SEGMENTS]);
             Assert.AreEqual(this.Filters, requestParameters[Constants.FILTERS]);
             Assert.AreEqual(this.TestCells, requestParameters[Constants.TEST_CELLS]);
+            Assert.AreEqual(this.FiltersPerSection, requestParameters[Constants.FILTERS_PER_SECTION]);
         }
 
         [Test]

--- a/src/Constructorio_NET.Tests/utils/HelpersTest.cs
+++ b/src/Constructorio_NET.Tests/utils/HelpersTest.cs
@@ -207,6 +207,7 @@ namespace Constructorio_NET.Tests
             bool regexMatched2 = Regex.Match(url, expectedUrl2).Success;
             Assert.That(regexMatched1 && regexMatched2, "url should be properly formed");
         }
+
         [Test]
         public void MakeUrlSearchWithFiltersPerSection()
         {

--- a/src/Constructorio_NET.Tests/utils/HelpersTest.cs
+++ b/src/Constructorio_NET.Tests/utils/HelpersTest.cs
@@ -207,5 +207,25 @@ namespace Constructorio_NET.Tests
             bool regexMatched2 = Regex.Match(url, expectedUrl2).Success;
             Assert.That(regexMatched1 && regexMatched2, "url should be properly formed");
         }
+        [Test]
+        public void MakeUrlSearchWithFiltersPerSection()
+        {
+            List<string> paths = new List<string> { "search", this.Query };
+            Dictionary<string, Dictionary<string, List<string>>> filtersPerSection = new Dictionary<string, Dictionary<string, List<string>>>
+            {
+                { "Products", new Dictionary<string, List<string>>() { { "Color", new List<string>() { "blue", "green" } } } }
+            };
+            Hashtable queryParams = new Hashtable()
+            {
+                { Constants.FILTERS_PER_SECTION, filtersPerSection },
+            };
+
+            string url = MakeUrl(this.Options, paths, queryParams);
+            string filterParameterBlue = "&filters%5BProducts%5D%5BColor%5D=blue";
+            string filterParameterGreen = "&filters%5BProducts%5D%5BColor%5D=green";
+            bool hasColorBlueFilter = Regex.Match(url, filterParameterBlue).Success;
+            bool hasColorGreenFilter = Regex.Match(url, filterParameterGreen).Success;
+            Assert.That(hasColorBlueFilter && hasColorGreenFilter, "url is properly formed and has all filters applied");
+        }
     }
 }

--- a/src/constructor.io/models/Autocomplete/AutocompleteRequest.cs
+++ b/src/constructor.io/models/Autocomplete/AutocompleteRequest.cs
@@ -27,6 +27,11 @@ namespace Constructorio_NET.Models
         public Dictionary<string, List<string>> Filters { get; set; }
 
         /// <summary>
+        /// Gets or sets filters per section used to refine results.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, List<string>>> FiltersPerSection { get; set; }
+
+        /// <summary>
         /// Gets or sets hidden metadata fields to return.
         /// </summary>
         public List<string> HiddenFields { get; set; }
@@ -93,6 +98,11 @@ namespace Constructorio_NET.Models
             if (this.Filters != null)
             {
                 parameters.Add(Constants.FILTERS, this.Filters);
+            }
+
+            if (this.FiltersPerSection != null)
+            {
+                parameters.Add(Constants.FILTERS_PER_SECTION, this.FiltersPerSection);
             }
 
             if (this.TestCells != null)

--- a/src/constructor.io/models/common/Result.cs
+++ b/src/constructor.io/models/common/Result.cs
@@ -31,4 +31,3 @@ namespace Constructorio_NET.Models
         public Dictionary<string, object> Labels { get; set; }
     }
 }
-

--- a/src/constructor.io/utils/Constants.cs
+++ b/src/constructor.io/utils/Constants.cs
@@ -8,6 +8,7 @@
         public const string CONSTRUCTOR_TOKEN = "constructorToken";
         public const string FACET_NAME = "facet_name";
         public const string FILTERS = "filters";
+        public const string FILTERS_PER_SECTION = "filters_per_section";
         public const string FMT_OPTIONS = "fmt_options";
         public const string FORCE = "force";
         public const string HIDDEN_FIELDS = "hidden_fields";

--- a/src/constructor.io/utils/Helpers.cs
+++ b/src/constructor.io/utils/Helpers.cs
@@ -113,6 +113,26 @@ namespace Constructorio_NET.Utils
                     }
                 }
 
+                if (queryParams.Contains(Constants.FILTERS_PER_SECTION))
+                {
+
+                    Dictionary<string, Dictionary<string, List<string>>> filtersPerSection = (Dictionary<string, Dictionary<string, List<string>>>)queryParams[Constants.FILTERS_PER_SECTION];
+                    queryParams.Remove(Constants.FILTERS);
+
+                    foreach (var section in filtersPerSection)
+                    {
+                        foreach (var filter in filtersPerSection[section.Key])
+                        {
+                            string sectionName = section.Key;
+                            string filterGroup = filter.Key;
+                            foreach (string filterOption in filter.Value)
+                            {
+                                url.Append($"&{Constants.FILTERS}{OurEscapeDataString("[" + sectionName + "]")}{OurEscapeDataString("[" + filterGroup + "]")}={OurEscapeDataString(filterOption)}");
+                            }
+                        }
+                    }
+                }
+
                 // Add test cells to query string
                 if (queryParams.Contains(Constants.TEST_CELLS))
                 {

--- a/src/constructor.io/utils/Helpers.cs
+++ b/src/constructor.io/utils/Helpers.cs
@@ -115,9 +115,8 @@ namespace Constructorio_NET.Utils
 
                 if (queryParams.Contains(Constants.FILTERS_PER_SECTION))
                 {
-
                     Dictionary<string, Dictionary<string, List<string>>> filtersPerSection = (Dictionary<string, Dictionary<string, List<string>>>)queryParams[Constants.FILTERS_PER_SECTION];
-                    queryParams.Remove(Constants.FILTERS);
+                    queryParams.Remove(Constants.FILTERS_PER_SECTION);
 
                     foreach (var section in filtersPerSection)
                     {


### PR DESCRIPTION
- Add `FiltersPerSection` property to `AutocompleteRequest`
- Change `GetRequestParameters` in `AutocompleteRequest` to add filters per section to parameter hashtable 
- Change `MakeUrl` util function to add properly formatted query params for all filters added per section
- Update tests and add test scenarios for new changes