### PR TITLE
[CDX-211] Support for JSONL in Catalog API

### DIFF
--- a/src/Constructorio_NET.Tests/models/Catalog/CatalogRequestTest.cs
+++ b/src/Constructorio_NET.Tests/models/Catalog/CatalogRequestTest.cs
@@ -51,5 +51,42 @@ namespace Constructorio_NET.Tests
         {
             Assert.Throws<ArgumentException>(() => new CatalogRequest(null));
         }
+
+        [Test]
+        public void DefaultFormatIsCsv()
+        {
+            CatalogRequest req = new CatalogRequest(this.Files);
+            Assert.AreEqual(CatalogRequest.FormatType.CSV, req.Format);
+        }
+
+        [Test]
+        public void FormatCanBeSetToJsonl()
+        {
+            CatalogRequest req = new CatalogRequest(this.Files)
+            {
+                Format = CatalogRequest.FormatType.JSONL
+            };
+            Assert.AreEqual(CatalogRequest.FormatType.JSONL, req.Format);
+        }
+
+        [Test]
+        public void GetRequestParametersWithDefaultFormat()
+        {
+            CatalogRequest req = new CatalogRequest(this.Files);
+            Hashtable requestParameters = req.GetRequestParameters();
+            Assert.IsFalse(requestParameters.ContainsKey(Constants.FORMAT));
+        }
+
+        [Test]
+        public void GetRequestParametersWithJsonlFormat()
+        {
+            CatalogRequest req = new CatalogRequest(this.Files)
+            {
+                Format = CatalogRequest.FormatType.JSONL
+            };
+            Hashtable requestParameters = req.GetRequestParameters();
+            Assert.IsTrue(requestParameters.ContainsKey(Constants.FORMAT));
+            Assert.AreEqual("jsonl", requestParameters[Constants.FORMAT]);
+        }
     }
 }

--- a/src/constructor.io/models/Catalog/CatalogRequest.cs
+++ b/src/constructor.io/models/Catalog/CatalogRequest.cs
@@ -29,6 +29,19 @@ namespace Constructorio_NET.Models
             IGNORE
         }
 
+        public enum FormatType
+        {
+            /// <summary>
+            /// CSV format (default).
+            /// </summary>
+            CSV,
+
+            /// <summary>
+            /// JSON Lines format.
+            /// </summary>
+            JSONL
+        }
+
         /// <summary>
         /// Gets or sets collection of files to upload.
         /// </summary>
@@ -55,6 +68,11 @@ namespace Constructorio_NET.Models
         public OnMissingStrategy OnMissing { get; set; }
 
         /// <summary>
+        /// Gets or sets the format of the files. Defaults to "CSV".
+        /// </summary>
+        public FormatType Format { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CatalogRequest"/> class.
         /// </summary>
         /// <param name="files">Dictionary of stream content to for the request.</param>
@@ -69,6 +87,7 @@ namespace Constructorio_NET.Models
 
             this.Files = files;
             this.OnMissing = OnMissingStrategy.FAIL;
+            this.Format = FormatType.CSV;
         }
 
         /// <summary>
@@ -97,6 +116,11 @@ namespace Constructorio_NET.Models
             if (this.OnMissing != OnMissingStrategy.FAIL)
             {
                 parameters.Add(Constants.ON_MISSING, this.OnMissing.ToString());
+            }
+
+            if (this.Format != FormatType.CSV)
+            {
+                parameters.Add(Constants.FORMAT, this.Format.ToString().ToLower());
             }
 
             parameters.Add(Constants.SECTION, this.Section);

--- a/src/constructor.io/utils/Constants.cs
+++ b/src/constructor.io/utils/Constants.cs
@@ -45,5 +45,6 @@
         public const string QUIZ_SESSION_ID = "quiz_session_id";
         public const string PRE_FILTER_EXPRESSION = "pre_filter_expression";
         public const string ON_MISSING = "on_missing";
+        public const string FORMAT = "format";
     }
 }


### PR DESCRIPTION
This pull request adds support for specifying the file format (CSV or JSONL) when creating a `CatalogRequest`. The default format is CSV, but it can be set to JSONL, and the format is now included in the request parameters when applicable. Comprehensive unit tests have been added to verify this new functionality.

**CatalogRequest format support:**

* Added a `FormatType` enum to `CatalogRequest` with options for `CSV` (default) and `JSONL`, and a `Format` property to specify the desired format. The constructor now defaults `Format` to `CSV`. 
* Updated the `GetRequestParameters` method in `CatalogRequest` to include the `format` parameter only if the format is not the default (`CSV`).
* Added a new constant `FORMAT` to the `Constants` class for use in request parameters. (`src/constructor.io/utils/Constants.cs`)

**Testing:**

* Added unit tests to verify the default format, the ability to set the format to JSONL, and the correct inclusion or exclusion of the `format` parameter in request parameters. (`src/Constructorio_NET.Tests/models/Catalog/CatalogRequestTest.cs`)


<img width="1172" height="203" alt="image" src="https://github.com/user-attachments/assets/f6a181b3-bb9b-496f-b47e-533eff1c985a" />
