### PR TITLE
Avoid allocating a Regex for every call of OurEscapeDataString, reuse a compiled Regex

### DIFF
--- a/src/constructor.io/utils/Helpers.cs
+++ b/src/constructor.io/utils/Helpers.cs
@@ -15,6 +15,7 @@ namespace Constructorio_NET.Utils
     public class Helpers
     {
         protected static readonly HttpMethod HttpMethodPatch = new HttpMethod("PATCH");
+        private static readonly Regex WhitespaceRegex = new Regex(@"\s", RegexOptions.Compiled);
 
         protected Helpers()
         {
@@ -27,7 +28,7 @@ namespace Constructorio_NET.Utils
         /// <returns>Url encoded string.</returns>
         protected static string OurEscapeDataString(string str)
         {
-            string encodedString = Regex.Replace(str, @"\s", " ");
+            string encodedString = WhitespaceRegex.Replace(str, " ");
             encodedString = Uri.EscapeDataString(encodedString);
 
             return encodedString;


### PR DESCRIPTION
Inside the static `Regex.Replace` method, a `Regex` is new'ed and has to be garbage collected at some point...