### PR TITLE
Reuse omittedQueryParams, they are not modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,5 @@ Constructorio_NET/Constructorio_NET.Tests/resources/csv/*
 .config/local.json
 
 .DS_Store
+
+/src/.idea/*

--- a/src/constructor.io/client/modules/Browse.cs
+++ b/src/constructor.io/client/modules/Browse.cs
@@ -100,12 +100,8 @@ namespace Constructorio_NET.Modules
         {
             Hashtable queryParams = req.GetRequestParameters();
             List<string> paths = new List<string> { "browse", "facets" };
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-            };
 
-            return MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            return MakeUrl(this.Options, paths, queryParams, OmitDtQueryParam);
         }
 
         /// <summary>
@@ -141,12 +137,8 @@ namespace Constructorio_NET.Modules
         {
             Hashtable queryParams = req.GetRequestParameters();
             List<string> paths = new List<string> { "browse", "facet_options" };
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-            };
 
-            return MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            return MakeUrl(this.Options, paths, queryParams, OmitDtQueryParam);
         }
 
         /// <summary>

--- a/src/constructor.io/client/modules/Catalog.cs
+++ b/src/constructor.io/client/modules/Catalog.cs
@@ -28,12 +28,7 @@ namespace Constructorio_NET.Modules
         {
             List<string> paths = new List<string> { "v1", "catalog" };
             Hashtable queryParams = req.GetRequestParameters();
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-                { "c", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtAndCQueryParams);
 
             return url;
         }
@@ -48,11 +43,7 @@ namespace Constructorio_NET.Modules
             }
 
             Hashtable queryParams = req.GetRequestParameters();
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtQueryParam);
 
             return url;
         }
@@ -61,12 +52,7 @@ namespace Constructorio_NET.Modules
         {
             List<string> paths = new List<string> { "v1", "searchabilities" };
             Hashtable queryParams = req.GetRequestParameters();
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-                { "c", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtAndCQueryParams);
 
             return url;
         }
@@ -75,12 +61,7 @@ namespace Constructorio_NET.Modules
         {
             List<string> paths = new List<string> { "v1", "searchabilities" };
             Hashtable queryParams = req.GetRequestParameters();
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-                { "c", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtAndCQueryParams);
 
             return url;
         }
@@ -481,13 +462,7 @@ namespace Constructorio_NET.Modules
                 queryParams.Add(Constants.SECTION, section);
             }
 
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-                { "c", true },
-            };
-
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtAndCQueryParams);
 
             return url;
         }
@@ -773,13 +748,7 @@ namespace Constructorio_NET.Modules
                 queryParams.Add(Constants.SECTION, section);
             }
 
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-                { "c", true },
-            };
-
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtAndCQueryParams);
 
             return url;
         }
@@ -1139,12 +1108,7 @@ namespace Constructorio_NET.Modules
                 queryParams.Add("sort_by", req.SortBy);
             }
 
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-                { "c", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtAndCQueryParams);
 
             return url;
         }
@@ -1263,12 +1227,7 @@ namespace Constructorio_NET.Modules
                 paths.Add(filterBySortOrder.ToString().ToLower());
             }
 
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-                { "c", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtAndCQueryParams);
 
             return url;
         }

--- a/src/constructor.io/client/modules/Items.cs
+++ b/src/constructor.io/client/modules/Items.cs
@@ -49,11 +49,7 @@ namespace Constructorio_NET.Modules
                 queryParams.Add(Constants.ON_MISSING, onMissing.ToString());
             }
 
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtQueryParam);
 
             return url;
         }
@@ -82,11 +78,7 @@ namespace Constructorio_NET.Modules
                 queryParams.Add(Constants.ON_MISSING, onMissing.ToString());
             }
 
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtQueryParam);
 
             return url;
         }
@@ -95,11 +87,7 @@ namespace Constructorio_NET.Modules
         {
             List<string> paths = new List<string> { "v2", "items" };
             Hashtable queryParams = req.GetRequestParameters();
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtQueryParam);
 
             return url;
         }
@@ -108,11 +96,7 @@ namespace Constructorio_NET.Modules
         {
             List<string> paths = new List<string> { "v2", "variations" };
             Hashtable queryParams = req.GetRequestParameters();
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtQueryParam);
             return url;
         }
 

--- a/src/constructor.io/client/modules/Tasks.cs
+++ b/src/constructor.io/client/modules/Tasks.cs
@@ -28,12 +28,7 @@ namespace Constructorio_NET.Modules
         {
             List<string> paths = new List<string> { "v1", "tasks" };
             Hashtable queryParams = req.GetRequestParameters();
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "_dt", true },
-                { "c", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtAndCQueryParams);
             return url;
         }
 
@@ -64,11 +59,7 @@ namespace Constructorio_NET.Modules
         {
             List<string> paths = new List<string> { "v1", "tasks", $"{req.TaskId}" };
             Hashtable queryParams = req.GetRequestParameters();
-            Dictionary<string, bool> omittedQueryParams = new Dictionary<string, bool>()
-            {
-                { "c", true },
-            };
-            string url = MakeUrl(this.Options, paths, queryParams, omittedQueryParams);
+            string url = MakeUrl(this.Options, paths, queryParams, OmitDtQueryParam);
 
             return url;
         }

--- a/src/constructor.io/utils/Helpers.cs
+++ b/src/constructor.io/utils/Helpers.cs
@@ -16,6 +16,16 @@ namespace Constructorio_NET.Utils
     {
         protected static readonly HttpMethod HttpMethodPatch = new HttpMethod("PATCH");
 
+        protected static readonly Dictionary<string, bool> OmitDtQueryParam = new Dictionary<string, bool>()
+        {
+            { "_dt", true },
+        };
+        protected static readonly Dictionary<string, bool> OmitDtAndCQueryParams = new Dictionary<string, bool>
+        {
+            { "_dt", true },
+            { "c", true },
+        };
+
         protected Helpers()
         {
         }


### PR DESCRIPTION
This avoids creation, allocation & garbage collect of omittedQueryParams dictionaries

Also added Rider files to .gitignore