### PR TITLE
[CDX-455] Add facet_groups_limit fmt_options support to .NET SDK

### DIFF
--- a/src/Constructorio_NET.Tests/models/common/FmtOptionsTest.cs
+++ b/src/Constructorio_NET.Tests/models/common/FmtOptionsTest.cs
@@ -129,10 +129,20 @@ namespace Constructorio_NET.Tests
         }
 
         [Test]
+        public void GetQueryParametersFacetGroupsLimit()
+        {
+            FmtOptions fmtOptions = new FmtOptions { FacetGroupsLimit = 10 };
+            Hashtable result = fmtOptions.GetQueryParameters();
+            Assert.AreEqual("10", result[$"{Constants.FMT_OPTIONS}[{Constants.FACET_GROUPS_LIMIT}]"]);
+            Assert.AreEqual(1, result.Count);
+        }
+
+        [Test]
         public void GetQueryParametersAllProperties()
         {
             FmtOptions fmtOptions = new FmtOptions
             {
+                FacetGroupsLimit = 20,
                 GroupsMaxDepth = 5,
                 GroupsStart = "top",
                 ShowHiddenFields = true,
@@ -145,7 +155,8 @@ namespace Constructorio_NET.Tests
             };
 
             Hashtable result = fmtOptions.GetQueryParameters();
-            Assert.AreEqual(9, result.Count);
+            Assert.AreEqual(10, result.Count);
+            Assert.AreEqual("20", result[$"{Constants.FMT_OPTIONS}[{Constants.FACET_GROUPS_LIMIT}]"]);
             Assert.AreEqual("5", result[$"{Constants.FMT_OPTIONS}[{Constants.GROUPS_MAX_DEPTH}]"]);
             Assert.AreEqual("top", result[$"{Constants.FMT_OPTIONS}[{Constants.GROUPS_START}]"]);
             Assert.AreEqual("true", result[$"{Constants.FMT_OPTIONS}[{Constants.SHOW_HIDDEN_FIELDS}]"]);

--- a/src/Constructorio_NET.Tests/utils/HelpersTest.cs
+++ b/src/Constructorio_NET.Tests/utils/HelpersTest.cs
@@ -290,6 +290,7 @@ namespace Constructorio_NET.Tests
             List<string> paths = new List<string> { "search", this.Query };
             Hashtable queryParams = new Hashtable()
             {
+                { $"{Constants.FMT_OPTIONS}[{Constants.FACET_GROUPS_LIMIT}]", "10" },
                 { $"{Constants.FMT_OPTIONS}[{Constants.GROUPS_MAX_DEPTH}]", "5" },
                 { $"{Constants.FMT_OPTIONS}[{Constants.GROUPS_START}]", "top" },
                 { $"{Constants.FMT_OPTIONS}[{Constants.SHOW_HIDDEN_FIELDS}]", "true" },
@@ -302,6 +303,7 @@ namespace Constructorio_NET.Tests
             };
 
             string url = MakeUrl(this.Options, paths, queryParams);
+            Assert.That(Regex.Match(url, "&fmt_options%5Bfacet_groups_limit%5D=10").Success, "should have facet_groups_limit");
             Assert.That(Regex.Match(url, "&fmt_options%5Bgroups_max_depth%5D=5").Success, "should have groups_max_depth");
             Assert.That(Regex.Match(url, "&fmt_options%5Bgroups_start%5D=top").Success, "should have groups_start");
             Assert.That(Regex.Match(url, "&fmt_options%5Bshow_hidden_fields%5D=true").Success, "should have show_hidden_fields");

--- a/src/constructor.io/models/common/FmtOptions.cs
+++ b/src/constructor.io/models/common/FmtOptions.cs
@@ -10,6 +10,11 @@ namespace Constructorio_NET.Models
     public class FmtOptions
     {
         /// <summary>
+        /// Gets or sets the maximum number of facet groups to return.
+        /// </summary>
+        public int? FacetGroupsLimit { get; set; }
+
+        /// <summary>
         /// Gets or sets the maximum depth of result groups to return.
         /// </summary>
         public int? GroupsMaxDepth { get; set; }
@@ -74,6 +79,11 @@ namespace Constructorio_NET.Models
         public Hashtable GetQueryParameters()
         {
             Hashtable parameters = new Hashtable();
+
+            if (this.FacetGroupsLimit.HasValue)
+            {
+                parameters.Add($"{Constants.FMT_OPTIONS}[{Constants.FACET_GROUPS_LIMIT}]", this.FacetGroupsLimit.Value.ToString());
+            }
 
             if (this.GroupsMaxDepth.HasValue)
             {

--- a/src/constructor.io/utils/Constants.cs
+++ b/src/constructor.io/utils/Constants.cs
@@ -6,6 +6,7 @@
         public const string API_TOKEN = "apiToken";
         public const string CLIENT_ID = "i";
         public const string CONSTRUCTOR_TOKEN = "constructorToken";
+        public const string FACET_GROUPS_LIMIT = "facet_groups_limit";
         public const string FACET_NAME = "facet_name";
         public const string FILTERS = "filters";
         public const string FILTERS_PER_SECTION = "filters_per_section";


### PR DESCRIPTION
Add facet_groups_limit support to FmtOptions model, allowing users to limit the number of facet groups returned in search/browse responses.